### PR TITLE
Update ProjModuleCollect.cmake for WS2811 driver

### DIFF
--- a/project/OpenBeken/ProjModuleCollect.cmake
+++ b/project/OpenBeken/ProjModuleCollect.cmake
@@ -119,6 +119,8 @@ set(MCU_SRC
     ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_wdt.c
     ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_trng.c
     ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_gpio.c
+    ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_dma.c
+    ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_ws2811.c
     ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_interrupt.c
     ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_clock.c
     ${MCU_LN882X_DIR}/driver_${CHIP_SERIAL}/hal/hal_misc.c


### PR DESCRIPTION
Added missing sources for cmake.

Needs to be merged before https://github.com/openshwprojects/OpenBK7231T_App/pull/1414